### PR TITLE
Upgrade Newtonsoft to 13.0.1 to avoid vulnerability.

### DIFF
--- a/FlashCap.V4L2Generator/FlashCap.V4L2Generator.csproj
+++ b/FlashCap.V4L2Generator/FlashCap.V4L2Generator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I suggest updating Newtonsoft.json version to 13.0.1 to prevent an Insecure Default vulnerability in some versions which could lead to a DoS exploit.