### PR TITLE
fix issue nr 60

### DIFF
--- a/FlashCap.Core/Devices/V4L2Devices.cs
+++ b/FlashCap.Core/Devices/V4L2Devices.cs
@@ -25,18 +25,17 @@ public sealed class V4L2Devices : CaptureDevices
     private static IEnumerable<v4l2_fmtdesc> EnumerateFormatDesc(
         int fd) =>
         Enumerable.Range(0, 1000).
-        CollectWhile(index =>
-        {
-            var fmtdesc = Interop.Create_v4l2_fmtdesc();
-            fmtdesc.index = (uint)index;
-            fmtdesc.type = (uint)v4l2_buf_type.VIDEO_CAPTURE;
+            CollectWhile(index =>
+            {
+                var fmtdesc = Interop.Create_v4l2_fmtdesc();
+                fmtdesc.index = (uint)index;
+                fmtdesc.type = (uint)v4l2_buf_type.VIDEO_CAPTURE;
             
-            return
-                ioctl(fd, Interop.VIDIOC_ENUM_FMT, fmtdesc) == 0 &&
-                IsKnownPixelFormat(fmtdesc.pixelformat) ?
-                (v4l2_fmtdesc?)fmtdesc : null;
-        }).
-        ToArray();   // Important: Iteration process must be continuous, avoid ioctl calls with other requests.
+                return
+                    ioctl(fd, Interop.VIDIOC_ENUM_FMT, fmtdesc) == 0 ? (v4l2_fmtdesc?)fmtdesc : null;
+            }).
+            Where(fmtdesc => IsKnownPixelFormat(fmtdesc.pixelformat)).
+            ToArray();    // Important: Iteration process must be continuous, avoid ioctl calls with other requests.
 
     private struct FrameSize
     {


### PR DESCRIPTION
when an unknown pixelformat preceeds known formats the CollectWhile stops too soon. This fixes the issue regarding pixelformats entering the enumarator YUYV, H.264, MJPG