### PR TITLE
Added CameraControlProperty interface

### DIFF
--- a/FlashCap.Core/CameraControlProperty.cs
+++ b/FlashCap.Core/CameraControlProperty.cs
@@ -1,0 +1,13 @@
+﻿namespace FlashCap
+{
+    public enum CameraControlProperty
+    {
+        Pan = 0,
+        Tilt,
+        Roll,
+        Zoom,
+        Exposure,
+        Iris,
+        Focus
+    }
+}

--- a/FlashCap.Core/CaptureDevice.cs
+++ b/FlashCap.Core/CaptureDevice.cs
@@ -70,6 +70,8 @@ public abstract class CaptureDevice :
     protected abstract void OnCapture(
         IntPtr pData, int size, long timestampMicroseconds, long frameIndex, PixelBuffer buffer);
 
+    protected abstract void SetControlProperty(CameraControlProperty property, int value);
+
     //////////////////////////////////////////////////////////////////////////
 
     internal Task InternalInitializeAsync(
@@ -101,4 +103,7 @@ public abstract class CaptureDevice :
     internal void InternalOnCapture(
         IntPtr pData, int size, long timestampMicroseconds, long frameIndex, PixelBuffer buffer) =>
         this.OnCapture(pData, size, timestampMicroseconds, frameIndex, buffer);
+
+    internal void InternalSetControlProperty(CameraControlProperty property, int value) =>
+        this.SetControlProperty(property, value);
 }

--- a/FlashCap.Core/Devices/V4L2Device.cs
+++ b/FlashCap.Core/Devices/V4L2Device.cs
@@ -427,4 +427,9 @@ public sealed class V4L2Device : CaptureDevice
         long timestampMicroseconds, long frameIndex,
         PixelBuffer buffer) =>
         buffer.CopyIn(this.pBih, pData, size, timestampMicroseconds, frameIndex, this.transcodeIfYUV);
+
+    protected override void SetControlProperty(CameraControlProperty property, int value)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/FlashCap.Core/Devices/VideoForWindowsDevice.cs
+++ b/FlashCap.Core/Devices/VideoForWindowsDevice.cs
@@ -286,4 +286,9 @@ public sealed class VideoForWindowsDevice : CaptureDevice
         IntPtr pData, int size, long timestampMicroseconds, long frameIndex,
         PixelBuffer buffer) =>
         buffer.CopyIn(this.pBih, pData, size, timestampMicroseconds, frameIndex, this.transcodeIfYUV);
+
+    protected override void SetControlProperty(CameraControlProperty property, int value)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/FlashCap.Core/Internal/NativeMethods_DirectShow.cs
+++ b/FlashCap.Core/Internal/NativeMethods_DirectShow.cs
@@ -572,6 +572,44 @@ internal static class NativeMethods_DirectShow
         [PreserveSig] int StopWhenReady();
     }
 
+    [Flags]
+    public enum CameraControlFlags
+    {
+        None = 0x0,
+        Auto = 0x0001,
+        Manual = 0x0002
+    }
+
+    [SuppressUnmanagedCodeSecurity]
+    [Guid("C6E13370-30AC-11d0-A18C-00A0C9118956")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IAMCameraControl
+    {
+        [PreserveSig]
+        int GetRange(
+            [In] CameraControlProperty Property,
+            [Out] out int pMin,
+            [Out] out int pMax,
+            [Out] out int pSteppingDelta,
+            [Out] out int pDefault,
+            [Out] out CameraControlFlags pCapsFlags
+            );
+
+        [PreserveSig]
+        int Set(
+            [In] CameraControlProperty Property,
+            [In] int lValue,
+            [In] CameraControlFlags Flags
+            );
+
+        [PreserveSig]
+        int Get(
+            [In] CameraControlProperty Property,
+            [Out] out int lValue,
+            [Out] out CameraControlFlags Flags
+            );
+    }
+
     ////////////////////////////////////////////////////////////////////////
 
     public static readonly Guid CLSID_SystemDeviceEnum =

--- a/FlashCap/CaptureDeviceExtension.cs
+++ b/FlashCap/CaptureDeviceExtension.cs
@@ -28,6 +28,9 @@ public static class CaptureDeviceExtension
     public static Task StopAsync(this CaptureDevice captureDevice, CancellationToken ct = default) =>
         captureDevice.InternalStopAsync(ct);
 
+    public static void SetControlProperty(this CaptureDevice captureDevice, CameraControlProperty property, int value) =>
+        captureDevice.InternalSetControlProperty(property, value);
+
     [Obsolete("Start method will be deprecated. Switch to use StartAsync method.")]
     public static void Start(this CaptureDevice captureDevice) =>
         _ = captureDevice.InternalStartAsync(default);


### PR DESCRIPTION
An implementation of the CameraControlProperty interface, only tested on DirectShow.

I needed this for a thermal camera where it uses the Zoom property in two ways: to switch frame data to raw thermal values (for further processing by the application), and to calibrate the camera (it has an internal shutter for calibration).


Example usage for the thermal camera:
```
this.captureDevice.SetControlProperty(CameraControlProperty.Zoom, 0x8000);    // 0x8000 = Calibrate
this.captureDevice.SetControlProperty(CameraControlProperty.Zoom, 0x8004);    // 0x8004 = Raw mode
```

This is incomplete however I wanted to create this PR to start some discussion about how this could be integrated into the main repo in a correct way.