### PR TITLE
feat: reduce tfm overlaps

### DIFF
--- a/FlashCap.Core/FlashCap.Core.csproj
+++ b/FlashCap.Core/FlashCap.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <IsPackable>true</IsPackable>

--- a/FlashCap.V4L2Generator/FlashCap.V4L2Generator.csproj
+++ b/FlashCap.V4L2Generator/FlashCap.V4L2Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/FlashCap/FlashCap.csproj
+++ b/FlashCap/FlashCap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <IsPackable>true</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
According to [this](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-3) document, reduce TFM overlaps.

| Pack | Actual Size | After PR|
|:-|-:|-:|
|FlashCap.Core| 2340 kb | 774 kb|