### PR TITLE
Add V4L2_PIX_FMT_NV12 implementation in loongarch64

### DIFF
--- a/FlashCap.Core/Internal/V4L2/NativeMethods_V4L2_Interop_loongarch64.cs
+++ b/FlashCap.Core/Internal/V4L2/NativeMethods_V4L2_Interop_loongarch64.cs
@@ -28,6 +28,7 @@ namespace FlashCap.Internal.V4L2
         public override uint V4L2_PIX_FMT_UYVY => 1498831189U;
         public override uint V4L2_PIX_FMT_XRGB32 => 875714626U;
         public override uint V4L2_PIX_FMT_YUYV => 1448695129U;
+        public override uint V4L2_PIX_FMT_NV12 => 842094158U;
         public override uint VIDIOC_DQBUF => 3227014673U;
         public override uint VIDIOC_ENUM_FMT => 3225441794U;
         public override uint VIDIOC_ENUM_FRAMEINTERVALS => 3224655435U;


### PR DESCRIPTION
Add V4L2_PIX_FMT_NV12 implementation in loongarch64，crash on loongarch64 if not.