### PR TITLE
macOS: Throw `NullReferenceException` when `Handle` is `nullptr`

### DIFF
--- a/FSharp.FlashCap/FSharp.FlashCap.fsproj
+++ b/FSharp.FlashCap/FSharp.FlashCap.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/FlashCap.Core/FlashCap.Core.csproj
+++ b/FlashCap.Core/FlashCap.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <IsPackable>true</IsPackable>

--- a/FlashCap.Core/Internal/AVFoundation/AVCaptureSession.cs
+++ b/FlashCap.Core/Internal/AVFoundation/AVCaptureSession.cs
@@ -23,6 +23,14 @@ partial class LibAVFoundation
             Init();
         }
 
+        private void ValidateHandle(string method)
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                throw new NullReferenceException($"{nameof(AVCaptureSession)} handle is NULL in '{method}'.");
+            }
+        }
+
         private void Init()
         {
             var sessionClass = LibObjC.SendAndGetHandle(
@@ -34,50 +42,61 @@ partial class LibAVFoundation
                 LibObjC.GetSelector("init"));
 
             Handle = sessionObj;
+            ValidateHandle(nameof(Init));
 
             LibCoreFoundation.CFRetain(this.Handle);
         }
 
-        public void AddInput(AVCaptureInput input) =>
+        public void AddInput(AVCaptureInput input)
+        {
+            ValidateHandle(nameof(AddInput));
+
             LibObjC.SendNoResult(
                 Handle,
                 LibObjC.GetSelector("addInput:"),
                 input.Handle);
+        }
 
         public void AddOutput(AVCaptureOutput output)
         {
             IntPtr allocSel = LibObjC.GetSelector("alloc");
             IntPtr initSel = LibObjC.GetSelector("init");
             
-            var videoDataOutputObj = output as AVCaptureVideoDataOutput ;
+            var videoDataOutputObj = output as AVCaptureVideoDataOutput 
+                ?? throw new Exception("Failed to get video data output") ;
 
-            if (videoDataOutputObj == null)
-            {
-                throw new Exception("Failed to get video data output");
-            }
-            
             var videoDataOutput = videoDataOutputObj.Handle;
-            
+
+            ValidateHandle(nameof(AddOutput));
             LibObjC.SendNoResult(
                 Handle,
                 LibObjC.GetSelector("addOutput:"),
                 videoDataOutput);
         }
 
-        public bool CanAddOutput(AVCaptureOutput output) =>
-            LibObjC.SendAndGetBool(
+        public bool CanAddOutput(AVCaptureOutput output)
+        {
+            ValidateHandle(nameof(CanAddOutput));
+            return LibObjC.SendAndGetBool(
                 Handle,
                 LibObjC.GetSelector("canAddOutput:"),
                 output.Handle);
+        }
 
-        public void StartRunning() =>
+        public void StartRunning()
+        {
+            ValidateHandle(nameof(StartRunning));
             LibObjC.SendNoResult(
                 Handle,
                 LibObjC.GetSelector("startRunning"));
+        }
 
-        public void StopRunning() =>
+        public void StopRunning()
+        {
+            ValidateHandle(nameof(StopRunning));
             LibObjC.SendNoResult(
                 Handle,
                 LibObjC.GetSelector("stopRunning"));
+        }
     }
 }

--- a/FlashCap.Core/Internal/AVFoundation/LibAVFoundation.cs
+++ b/FlashCap.Core/Internal/AVFoundation/LibAVFoundation.cs
@@ -9,7 +9,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Linq;
 using static FlashCap.Internal.NativeMethods_AVFoundation;
@@ -24,11 +23,11 @@ internal static partial class LibAVFoundation
 
     public delegate void AVRequestAccessStatus(bool accessGranted);
 
-    private static void ValidateHandle()
+    private static void ValidateHandle(string method)
     {
         if (Handle == IntPtr.Zero)
         {
-            throw new ObjectDisposedException(nameof(LibAVFoundation), "Handle invalid.");
+            throw new NullReferenceException($"{nameof(LibAVFoundation)} handle is NULL in '{method}'.");
         }
     }
     
@@ -234,7 +233,7 @@ internal static partial class LibAVFoundation
 
         public static unsafe void RequestAccessForMediaType(IntPtr mediaType, AVRequestAccessStatus completion)
         {
-            ValidateHandle();
+            ValidateHandle(nameof(RequestAccessForMediaType));
             RequestAccessForMediaTypeBlockFactory ??= LibObjC.BlockLiteralFactory.CreateFactory<RequestAccessForMediaTypeTrampoline>(
                 signature: "v@?^vC",
                 delegate (IntPtr block, byte accessGranted)
@@ -269,7 +268,7 @@ internal static partial class LibAVFoundation
 
         public static AVCaptureDeviceDiscoverySession DiscoverySessionWithVideoDevices()
         {
-            ValidateHandle();
+            ValidateHandle(nameof(DiscoverySessionWithVideoDevices));
             var deviceTypes = new[]
             {
                 AVCaptureDeviceType.BuiltInWideAngleCamera,
@@ -379,7 +378,7 @@ internal static partial class LibAVFoundation
     public abstract class AVCaptureVideoDataOutputSampleBuffer : LibObjC.NSObject
     {
         private const string HandleVariableName = nameof(GCHandle);
-        private static IntPtr HandleVariableDescriptor;
+        private static readonly IntPtr HandleVariableDescriptor;
 
         static AVCaptureVideoDataOutputSampleBuffer()
         {

--- a/FlashCap.Core/Internal/AVFoundation/LibAVFoundation.cs
+++ b/FlashCap.Core/Internal/AVFoundation/LibAVFoundation.cs
@@ -24,6 +24,14 @@ internal static partial class LibAVFoundation
 
     public delegate void AVRequestAccessStatus(bool accessGranted);
 
+    private static void ValidateHandle()
+    {
+        if (Handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(LibAVFoundation), "Handle invalid.");
+        }
+    }
+    
     public sealed class AVFrameRateRange : LibObjC.NSObject
     {
         public AVFrameRateRange(IntPtr handle, bool retain) :
@@ -226,6 +234,7 @@ internal static partial class LibAVFoundation
 
         public static unsafe void RequestAccessForMediaType(IntPtr mediaType, AVRequestAccessStatus completion)
         {
+            ValidateHandle();
             RequestAccessForMediaTypeBlockFactory ??= LibObjC.BlockLiteralFactory.CreateFactory<RequestAccessForMediaTypeTrampoline>(
                 signature: "v@?^vC",
                 delegate (IntPtr block, byte accessGranted)
@@ -260,6 +269,7 @@ internal static partial class LibAVFoundation
 
         public static AVCaptureDeviceDiscoverySession DiscoverySessionWithVideoDevices()
         {
+            ValidateHandle();
             var deviceTypes = new[]
             {
                 AVCaptureDeviceType.BuiltInWideAngleCamera,

--- a/FlashCap/FlashCap.csproj
+++ b/FlashCap/FlashCap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net461;net48;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/samples/FlashCap.Avalonia/FlashCap.Avalonia/FlashCap.Avalonia.csproj
+++ b/samples/FlashCap.Avalonia/FlashCap.Avalonia/FlashCap.Avalonia.csproj
@@ -2,7 +2,7 @@
     
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0;net10.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
This is a part of Felipe's PR which I slightly refactored. Felipe's original idea is captured by this snippet: https://github.com/kekyo/FlashCap/pull/171/changes#diff-828f820312b1a627c03e0e1ad658644159d006400607c23da042e4d5609d8865R59-R71. I used a guard method `ValidateHandle(nameof(<FromWhichMethodCalled>));`

The goal of this PR is to create a smaller more digestible chunk of #171 which is quite big for review and I believe it needs a bit more work to finish it.


cc @ffquintella 
cc @kekyo 